### PR TITLE
fix(rest-api): bootstrap projen with latest CLI version

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -30,7 +30,7 @@ Create a fresh AWS CDK app with Projen.
    ```
 1. Init AWS CDK with Projen:
    ```bash
-   npx projen new awscdk-app-ts --package-manager 'NPM' --github false --no-git
+   npx projen@latest new awscdk-app-ts --package-manager 'NPM' --github false --no-git
    ```
 1. Go to the file `./src/main.ts` and rename the stack, like so:
   ```typescript


### PR DESCRIPTION
I did run into problems using an outdated CLI version but getting the latest Projen dependencies within the generated project. That, of course, broke the config file because we pass NPM as the preferred package manager but the type didn't exist anymore. 

More context: https://github.com/npm/cli/issues/2329