### PR TITLE
fix(lab2): pinpoint node-fetch to v2.6.1

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -161,6 +161,7 @@ Integration tests are super helpful to test the whole stack end-to-end. Write so
      name: 'notes-api',
      packageManager: javascript.NodePackageManager.NPM,
      deps: [
+       'node-fetch@2.6.1',
        '@aws-sdk/client-dynamodb',
        '@aws-sdk/lib-dynamodb',
      ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -17360,7 +17360,7 @@
         "@aws-sdk/lib-dynamodb": "^3.165.0",
         "aws-cdk-lib": "^2.35.0",
         "constructs": "^10.0.5",
-        "node-fetch": "2"
+        "node-fetch": "2.6.1"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.103",
@@ -18925,20 +18925,11 @@
       }
     },
     "packages/lab2/node_modules/node-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.0.tgz",
-      "integrity": "sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
+        "node": "4.x || >=6.0.0"
       }
     },
     "packages/lab2/node_modules/normalize-url": {
@@ -32838,7 +32829,7 @@
         "jest": "^29",
         "jest-junit": "^13",
         "json-schema": "^0.4.0",
-        "node-fetch": "2",
+        "node-fetch": "2.6.1",
         "npm-check-updates": "^15",
         "projen": "^0.61.45",
         "ts-jest": "^28",
@@ -33983,13 +33974,9 @@
           }
         },
         "node-fetch": {
-          "version": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.0.tgz",
-          "integrity": "sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==",
-          "requires": {
-            "data-uri-to-buffer": "^4.0.0",
-            "fetch-blob": "^3.1.4",
-            "formdata-polyfill": "^4.0.10"
-          }
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "normalize-url": {
           "version": "6.1.0",

--- a/packages/lab2/.projen/deps.json
+++ b/packages/lab2/.projen/deps.json
@@ -112,7 +112,7 @@
     },
     {
       "name": "node-fetch",
-      "version": "2",
+      "version": "2.6.1",
       "type": "runtime"
     }
   ],

--- a/packages/lab2/.projenrc.js
+++ b/packages/lab2/.projenrc.js
@@ -6,7 +6,7 @@ const project = new awscdk.AwsCdkTypeScriptApp({
   github: false,
   packageManager: javascript.NodePackageManager.NPM,
   deps: [
-    'node-fetch@2',
+    'node-fetch@2.6.1',
     '@aws-sdk/client-dynamodb',
     '@aws-sdk/lib-dynamodb',
   ],

--- a/packages/lab2/package.json
+++ b/packages/lab2/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/lib-dynamodb": "^3.165.0",
     "aws-cdk-lib": "^2.35.0",
     "constructs": "^10.0.5",
-    "node-fetch": "2"
+    "node-fetch": "2.6.1"
   },
   "license": "Apache-2.0",
   "version": "0.0.0",


### PR DESCRIPTION
Node-fetch v3 only supports esm (ecma script modules). We cannot support this without refactoring so we pinpoint the version to 2.6.1

fixes #447